### PR TITLE
[feat] 로그인, 회원가입 기능구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,20 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'org.jsoup:jsoup:1.17.2'
+
+	// SpringDoc OpenAPI (Swagger)
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+	// Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// Email 전송
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/jobfeed/JobFeed/domain/user/controller/EmailController.java
+++ b/src/main/java/com/jobfeed/JobFeed/domain/user/controller/EmailController.java
@@ -1,0 +1,60 @@
+package com.jobfeed.JobFeed.domain.user.controller;
+
+import com.jobfeed.JobFeed.domain.user.dto.EmailRequestDto;
+import com.jobfeed.JobFeed.domain.user.dto.EmailVerifyDto;
+import com.jobfeed.JobFeed.domain.user.service.EmailService;
+import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/email")
+public class EmailController {
+
+    private final EmailService emailService;
+
+    @Operation(summary = "이메일 인증 코드 발송", description = "입력된 이메일로 6자리 인증 코드를 전송합니다. 인증 코드는 5분간 유효합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이메일 전송 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "이메일 누락",
+                                    value = "{ \"code\": \"E001\", \"message\": \"이메일은 필수입니다.\" }"
+                            )
+                    )
+            )
+    })
+    @PostMapping("/send")
+    public ResponseEntity<Void> sendAuthCode(@RequestBody @Valid EmailRequestDto request) {
+        emailService.sendAuthCode(request.getEmail());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "이메일 인증 코드 확인", description = "사용자가 입력한 인증 코드가 유효한지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증 성공"),
+            @ApiResponse(responseCode = "400", description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "코드 불일치",
+                                    value = "{ \"code\": \"E002\", \"message\": \"인증 코드가 유효하지 않습니다.\" }"
+                            )
+                    )
+            )
+    })
+    @PostMapping("/verify")
+    public ResponseEntity<Void> verifyAuthCode(@RequestBody @Valid EmailVerifyDto request) {
+        emailService.verifyCode(request.getEmail(), request.getAuthCode());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/jobfeed/JobFeed/domain/user/controller/UserController.java
+++ b/src/main/java/com/jobfeed/JobFeed/domain/user/controller/UserController.java
@@ -1,0 +1,120 @@
+package com.jobfeed.JobFeed.domain.user.controller;
+
+import com.jobfeed.JobFeed.domain.user.dto.LoginRequestDto;
+import com.jobfeed.JobFeed.domain.user.dto.SignupRequestDto;
+import com.jobfeed.JobFeed.domain.user.service.UserService;
+import com.jobfeed.JobFeed.global.auth.dto.TokenBox;
+import com.jobfeed.JobFeed.global.auth.userdetails.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "회원가입")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "400", description = "실패 케이스",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "아이디 중복",
+                                            value = "{ \"code\": \"U001\", \"message\": \"이미 사용 중인 아이디입니다.\" }"
+                                    ),
+                                    @ExampleObject(
+                                            name = "이메일 중복",
+                                            value = "{ \"code\": \"U002\", \"message\": \"이미 사용 중인 이메일입니다.\" }"
+                                    ),
+                                    @ExampleObject(
+                                            name = "이메일 인증 미완료",
+                                            value = "{ \"code\": \"U003\", \"message\": \"이메일 인증이 필요합니다.\" }"
+                                    ),
+                                    @ExampleObject(
+                                            name = "비밀번호 불일치",
+                                            value = "{ \"code\": \"U004\", \"message\": \"비밀번호와 비밀번호 확인이 일치하지 않습니다.\" }"
+                                    ),
+                                    @ExampleObject(
+                                            name = "요청값 형식 오류",
+                                            value = "{ \"code\": \"U005\", \"message\": \"요청한 값이 올바르지 않습니다.\" }"
+                                    )
+                            }
+                    )
+            )
+    })
+    @PostMapping("/auth/signup")
+    public ResponseEntity<Void> signUp(@Valid @RequestBody SignupRequestDto request) {
+        userService.signUp(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "토큰 갱신")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "토큰 갱신 성공 (Header로 토큰 반환)"),
+            @ApiResponse(responseCode = "400", description = "실패 케이스",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "RefreshToken 만료",
+                                            value = "{ \"code\": \"U006\", \"message\": \"토큰이 만료되었습니다.\" }"
+                                    )
+                            }
+                    )
+            )
+    })
+    @GetMapping("/auth/token")
+    public ResponseEntity<Void> tokenRotation(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        TokenBox tokenBox = userService.tokenRotation(userDetails);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Access-Token", tokenBox.getAccessToken());
+        headers.add("Refresh-Token", tokenBox.getRefreshToken());
+        headers.add("Authority", tokenBox.getAuthority());
+
+        return ResponseEntity.ok().headers(headers).build();
+    }
+
+    @Operation(summary = "로그인")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공 (Header로 토큰 반환)"),
+            @ApiResponse(responseCode = "401", description = "로그인 실패 (아이디 또는 비밀번호 불일치)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "로그인 실패",
+                                    value = "{ \"code\": \"U007\", \"message\": \"아이디 또는 비밀번호가 올바르지 않습니다.\" }"
+                            )
+                    )
+            )
+    })
+    @PostMapping("/auth/login")
+    public ResponseEntity<Void> login(@Valid @RequestBody LoginRequestDto request) {
+        TokenBox tokenBox = userService.login(request);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Access-Token", tokenBox.getAccessToken());
+        headers.add("Refresh-Token", tokenBox.getRefreshToken());
+        headers.add("Authority", tokenBox.getAuthority());
+
+        return ResponseEntity.ok().headers(headers).build();
+    }
+}

--- a/src/main/java/com/jobfeed/JobFeed/domain/user/dto/EmailRequestDto.java
+++ b/src/main/java/com/jobfeed/JobFeed/domain/user/dto/EmailRequestDto.java
@@ -1,0 +1,17 @@
+package com.jobfeed.JobFeed.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class EmailRequestDto {
+    @Schema(
+            description = "이메일 주소",
+            example = "user@example.com"
+    )
+    @Email
+    @NotBlank
+    private String email;
+}

--- a/src/main/java/com/jobfeed/JobFeed/domain/user/dto/EmailVerifyDto.java
+++ b/src/main/java/com/jobfeed/JobFeed/domain/user/dto/EmailVerifyDto.java
@@ -1,0 +1,22 @@
+package com.jobfeed.JobFeed.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class EmailVerifyDto {
+    @Schema(
+            description = "이메일 주소",
+            example = "user@example.com"
+    )
+    @NotBlank
+    private String email;
+
+    @Schema(
+            description = "이메일로 발송된 인증번호 (6자리)",
+            example = "123456"
+    )
+    @NotBlank
+    private String authCode;
+}

--- a/src/main/java/com/jobfeed/JobFeed/domain/user/dto/LoginRequestDto.java
+++ b/src/main/java/com/jobfeed/JobFeed/domain/user/dto/LoginRequestDto.java
@@ -1,0 +1,16 @@
+package com.jobfeed.JobFeed.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class LoginRequestDto {
+    @Schema(description = "사용자 아이디", example = "user123")
+    @NotBlank
+    private String username;
+
+    @Schema(description = "비밀번호", example = "Password123!")
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/jobfeed/JobFeed/domain/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/jobfeed/JobFeed/domain/user/dto/SignupRequestDto.java
@@ -1,0 +1,55 @@
+package com.jobfeed.JobFeed.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignupRequestDto {
+    @Schema(
+            description = "사용자 닉네임",
+            example = "홍길동"
+    )
+    @NotBlank
+    private String nickname;
+
+    @Schema(
+            description = "사용자 아이디",
+            example = "user123"
+    )
+    @NotBlank
+    private String username;
+
+    @Schema(
+            description = "비밀번호 (8~20자, 영문+숫자+특수문자)",
+            example = "Password123!"
+    )
+    @NotBlank
+    private String password;
+
+    @Schema(
+            description = "비밀번호 확인",
+            example = "Password123!"
+    )
+    @NotBlank
+    private String passwordConfirm;
+
+    @Schema(
+            description = "이메일 주소",
+            example = "user@example.com"
+    )
+    @Email
+    @NotBlank
+    private String email;
+
+    @Schema(
+            description = "이메일 인증 완료 여부",
+            example = "true"
+    )
+    @NotNull
+    private Boolean emailVerified;
+}

--- a/src/main/java/com/jobfeed/JobFeed/domain/user/entity/Role.java
+++ b/src/main/java/com/jobfeed/JobFeed/domain/user/entity/Role.java
@@ -1,0 +1,6 @@
+package com.jobfeed.JobFeed.domain.user.entity;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/jobfeed/JobFeed/domain/user/entity/User.java
+++ b/src/main/java/com/jobfeed/JobFeed/domain/user/entity/User.java
@@ -1,0 +1,64 @@
+package com.jobfeed.JobFeed.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_user_username", columnNames = "username"),
+                @UniqueConstraint(name = "uk_user_email", columnNames = "email")
+        },
+        indexes = {
+                @Index(name = "idx_user_created_at", columnList = "createdAt")
+        })
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String nickname;
+
+    @Column(nullable = false, length = 30)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, length = 100)
+    private String email;
+
+    @Column(nullable = false)
+    private Boolean emailVerified = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public User(String nickname, String username, String password, String email) {
+        this.nickname = nickname;
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.role = Role.USER;
+    }
+
+    public void verifyEmail() {
+        this.emailVerified = true;
+    }
+}

--- a/src/main/java/com/jobfeed/JobFeed/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/jobfeed/JobFeed/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,19 @@
+package com.jobfeed.JobFeed.domain.user.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode {
+    DUPLICATE_USERNAME("U001", "이미 사용 중인 아이디입니다."),
+    DUPLICATE_EMAIL("U002", "이미 사용 중인 이메일입니다."),
+    EMAIL_VERIFICATION_REQUIRED("U003", "이메일 인증이 필요합니다."),
+    PASSWORD_MISMATCH("U004", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    INVALID_REQUEST("U005", "요청한 값이 올바르지 않습니다."),
+    TOKEN_EXPIRED("U006", "토큰이 만료되었습니다."),
+    INVALID_CREDENTIALS("U007", "아이디 또는 비밀번호가 일치하지 않습니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/jobfeed/JobFeed/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/jobfeed/JobFeed/domain/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.jobfeed.JobFeed.domain.user.repository;
+
+import com.jobfeed.JobFeed.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByUsername(String username);
+    boolean existsByEmail(String email);
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/jobfeed/JobFeed/domain/user/service/EmailService.java
+++ b/src/main/java/com/jobfeed/JobFeed/domain/user/service/EmailService.java
@@ -1,0 +1,6 @@
+package com.jobfeed.JobFeed.domain.user.service;
+
+public interface EmailService {
+    void sendAuthCode(String email);
+    void verifyCode(String email, String authCode);
+}

--- a/src/main/java/com/jobfeed/JobFeed/domain/user/service/EmailServiceImpl.java
+++ b/src/main/java/com/jobfeed/JobFeed/domain/user/service/EmailServiceImpl.java
@@ -1,0 +1,47 @@
+package com.jobfeed.JobFeed.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class EmailServiceImpl implements EmailService {
+
+    private final JavaMailSender mailSender;
+    private final Map<String, String> authStorage = new HashMap<>();
+
+    @Override
+    public void sendAuthCode(String email) {
+        String code = UUID.randomUUID().toString().substring(0, 6).toUpperCase();
+
+        // 실제로는 Redis 같은 DB에 저장하는 게 안정적
+        authStorage.put(email, code);
+
+        String subject = "[JobFeed] 이메일 인증 코드입니다.";
+        String text = "인증 코드: " + code + "\n5분 내에 입력해 주세요.";
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject(subject);
+        message.setText(text);
+        message.setFrom("titeotty12@naver.com");
+
+        mailSender.send(message);
+        System.out.println("[메일 전송 완료] " + email + " → " + code);
+    }
+
+    @Override
+    public void verifyCode(String email, String authCode) {
+        String storedCode = authStorage.get(email);
+        if (storedCode == null || !storedCode.equalsIgnoreCase(authCode)) {
+            throw new IllegalArgumentException("인증 코드가 유효하지 않습니다.");
+        }
+        System.out.println("[인증 성공] " + email);
+    }
+}

--- a/src/main/java/com/jobfeed/JobFeed/domain/user/service/UserService.java
+++ b/src/main/java/com/jobfeed/JobFeed/domain/user/service/UserService.java
@@ -1,0 +1,113 @@
+package com.jobfeed.JobFeed.domain.user.service;
+
+import com.jobfeed.JobFeed.domain.user.dto.LoginRequestDto;
+import com.jobfeed.JobFeed.domain.user.dto.SignupRequestDto;
+import com.jobfeed.JobFeed.domain.user.entity.User;
+import com.jobfeed.JobFeed.domain.user.exception.UserErrorCode;
+import com.jobfeed.JobFeed.domain.user.repository.UserRepository;
+import com.jobfeed.JobFeed.global.auth.dto.TokenBox;
+import com.jobfeed.JobFeed.global.auth.jwt.JwtTokenProvider;
+import com.jobfeed.JobFeed.global.auth.userdetails.UserDetailsImpl;
+import com.jobfeed.JobFeed.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.security.core.Authentication;
+
+
+import static com.jobfeed.JobFeed.domain.user.exception.UserErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
+
+
+    @Transactional
+    public void signUp(SignupRequestDto request) {
+        // 비밀번호 일치 검증
+        if (!request.getPassword().equals(request.getPasswordConfirm())) {
+            throw new CustomException(
+                    PASSWORD_MISMATCH.getCode(),
+                    PASSWORD_MISMATCH.getMessage()
+            );
+        }
+
+        // 아이디 중복 검사
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw new CustomException(
+                    DUPLICATE_USERNAME.getCode(),
+                    DUPLICATE_USERNAME.getMessage()
+            );
+        }
+
+        // 이메일 중복 검사
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new CustomException(
+                    DUPLICATE_EMAIL.getCode(),
+                    DUPLICATE_EMAIL.getMessage()
+            );
+        }
+
+        // 이메일 인증 여부 확인
+        if (!request.getEmailVerified()) {
+            throw new CustomException(
+                    EMAIL_VERIFICATION_REQUIRED.getCode(),
+                    EMAIL_VERIFICATION_REQUIRED.getMessage()
+            );
+        }
+
+        // 엔티티 생성 및 저장
+        User user = User.builder()
+                .nickname(request.getNickname())
+                .username(request.getUsername())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .email(request.getEmail())
+                .build();
+
+        userRepository.save(user);
+    }
+
+    @Transactional
+    public TokenBox tokenRotation(UserDetailsImpl userDetails) {
+        // 실제 구현 시 JWT 유틸 클래스에서 토큰 생성 필요
+        return TokenBox.builder()
+                .accessToken("new-access-token")
+                .refreshToken("new-refresh-token")
+                .authority(userDetails.getAuthorities().toString())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public TokenBox login(LoginRequestDto request) {
+        User user = userRepository.findByUsername(request.getUsername())
+                .orElseThrow(() -> new CustomException(
+                        UserErrorCode.INVALID_CREDENTIALS.getCode(),
+                        UserErrorCode.INVALID_CREDENTIALS.getMessage()
+                ));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new CustomException(
+                    UserErrorCode.INVALID_CREDENTIALS.getCode(),
+                    "아이디 또는 비밀번호가 일치하지 않습니다."
+            );
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(user);
+        String refreshToken = jwtTokenProvider.createRefreshToken(user);
+
+        return TokenBox.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .authority(user.getRole().name())
+                .build();
+    }
+
+}

--- a/src/main/java/com/jobfeed/JobFeed/global/auth/dto/TokenBox.java
+++ b/src/main/java/com/jobfeed/JobFeed/global/auth/dto/TokenBox.java
@@ -1,0 +1,16 @@
+package com.jobfeed.JobFeed.global.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TokenBox {
+    private String accessToken;
+    private String refreshToken;
+    private String authority;
+}

--- a/src/main/java/com/jobfeed/JobFeed/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/jobfeed/JobFeed/global/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,88 @@
+package com.jobfeed.JobFeed.global.auth.jwt;
+
+import com.jobfeed.JobFeed.domain.user.entity.User;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey key;
+    private final long accessTokenValidityInMs;
+    private final long refreshTokenValidityInMs;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-validity-in-ms}") long accessTokenValidityInMs,
+            @Value("${jwt.refresh-token-validity-in-ms}") long refreshTokenValidityInMs
+    ) {
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+        this.accessTokenValidityInMs = accessTokenValidityInMs;
+        this.refreshTokenValidityInMs = refreshTokenValidityInMs;
+    }
+
+    // AccessToken 생성
+    public String createAccessToken(User user) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessTokenValidityInMs);
+
+        return Jwts.builder()
+                .setSubject(user.getUsername())
+                .claim("userId", user.getId())
+                .claim("role", user.getRole().name())
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // RefreshToken 생성
+    public String createRefreshToken(User user) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + refreshTokenValidityInMs);
+
+        return Jwts.builder()
+                .setSubject(user.getUsername())
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 토큰 유효성 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.debug("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.debug("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.debug("지원하지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.debug("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+
+    // 토큰에서 사용자명 추출
+    public String getUsername(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody().getSubject();
+    }
+
+    // 토큰에서 클레임 추출
+    public Claims getClaims(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody();
+    }
+}

--- a/src/main/java/com/jobfeed/JobFeed/global/auth/userdetails/UserDetailsImpl.java
+++ b/src/main/java/com/jobfeed/JobFeed/global/auth/userdetails/UserDetailsImpl.java
@@ -1,0 +1,56 @@
+package com.jobfeed.JobFeed.global.auth.userdetails;
+
+import com.jobfeed.JobFeed.domain.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 모든 유저는 ROLE_USER 권한을 가짐
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/jobfeed/JobFeed/global/config/SecurityConfig.java
+++ b/src/main/java/com/jobfeed/JobFeed/global/config/SecurityConfig.java
@@ -1,0 +1,57 @@
+package com.jobfeed.JobFeed.global.config;
+
+import jakarta.servlet.DispatcherType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    // 비밀번호 인코더
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // 보안 필터 체인 설정
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // CSRF 비활성화
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // JWT이므로 세션 X
+                .authorizeHttpRequests(auth -> auth
+                        // Swagger 관련 경로 허용
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/webjars/**"
+                        ).permitAll()
+                        // 이메일 인증 API 허용
+                        .requestMatchers("/api/email/**").permitAll()
+                        // 회원가입, 로그인 등은 허용
+                        .requestMatchers("/api/auth/**").permitAll()
+                        // 그 외는 인증 필요
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  access-token-validity-in-ms: 3600000       # 1시간
+  refresh-token-validity-in-ms: 1209600000   # 14일
+
+spring:
+  mail:
+    host: smtp.naver.com
+    port: 465
+    username: ${NAVER_MAIL}
+    password: ${NAVER_PASSWD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          ssl:
+            enable: true
+            trust: smtp.naver.com
+          starttls:
+            enable: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000


### PR DESCRIPTION
## 기능 구현
### SecurityConfig 설정
- CSRF 비활성화 및 세션 상태 STATELESS로 설정
- Swagger, 이메일 인증, 로그인/회원가입 경로는 비인증 허용
- 기타 요청은 인증 필요하도록 설정
- AuthenticationManager 빈 등록

### UserService
- 회원가입
    - 비밀번호 일치 확인
    - 사용자명, 이메일 중복 검사
    - 이메일 인증 여부 확인
    - 비밀번호 암호화
- 로그인
    - 사용자 존재 여부 및 비밀번호 검증
    - JWT AccessToken & RefreshToken 생성 및 반환

### EmailService
- 인증코드 발송
    - 6자리 랜덤 코드 생성 후 이메일 발송 (네이버 smtp 사용)
- 인증 코드 검증
    - 이메일 + 코드 매칭 확인

## 테스트
- 회원가입
![image](https://github.com/user-attachments/assets/08e4a743-d511-4215-ab38-62744ead063c)
![image](https://github.com/user-attachments/assets/e4a9d356-5584-4b38-a65d-87741fb5bfd1)

- 로그인
![image](https://github.com/user-attachments/assets/be9affba-d6c2-4f4d-a9b9-95874cbb2d3e)

- 이메일 인증번호 발송
![image](https://github.com/user-attachments/assets/6f31a5b5-9ecb-426f-92f8-ccf69f18bc5a)
![image](https://github.com/user-attachments/assets/d69f542a-b804-4bb5-a89c-8912cd366409)

- 인증번호 확인
![image](https://github.com/user-attachments/assets/04ff3ecc-fe37-45ee-a0f2-ba32fa77825c)

