### PR TITLE
[feat] 면접 리뷰 게시판 기능 구현

### DIFF
--- a/src/main/java/com/curpick/CurPick/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/curpick/CurPick/domain/review/controller/ReviewController.java
@@ -17,7 +17,7 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
-    // 🔹 후기 등록
+    // 후기 등록
     @PostMapping
     public ResponseEntity<ReviewResponseDto> createReview(@RequestBody ReviewRequestDto dto) {
         ReviewResponseDto created = reviewService.createReview(dto);
@@ -25,21 +25,21 @@ public class ReviewController {
                 .body(created);
     }
 
-    // 🔹 전체 후기 목록
+    // 전체 후기 목록
     @GetMapping
     public ResponseEntity<List<ReviewResponseDto>> getAllReviews() {
         List<ReviewResponseDto> reviews = reviewService.getAllReviews();
         return ResponseEntity.ok(reviews);
     }
 
-    // 🔹 단일 후기 조회
+    // 단일 후기 조회
     @GetMapping("/{id}")
     public ResponseEntity<ReviewResponseDto> getReview(@PathVariable Long id) {
         ReviewResponseDto review = reviewService.getReviewById(id);
         return ResponseEntity.ok(review);
     }
 
-    // 🔹 후기 수정
+    // 후기 수정
     @PutMapping("/{id}")
     public ResponseEntity<ReviewResponseDto> updateReview(@PathVariable Long id,
                                                           @RequestBody ReviewRequestDto dto) {
@@ -47,7 +47,7 @@ public class ReviewController {
         return ResponseEntity.ok(updated);
     }
 
-    // 🔹 후기 삭제
+    // 후기 삭제
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteReview(@PathVariable Long id) {
         reviewService.deleteReview(id);

--- a/src/main/java/com/curpick/CurPick/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/curpick/CurPick/domain/review/controller/ReviewController.java
@@ -1,0 +1,56 @@
+package com.curpick.CurPick.domain.review.controller;
+
+import com.curpick.CurPick.domain.review.dto.ReviewRequestDto;
+import com.curpick.CurPick.domain.review.dto.ReviewResponseDto;
+import com.curpick.CurPick.domain.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reviews")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    // 🔹 후기 등록
+    @PostMapping
+    public ResponseEntity<ReviewResponseDto> createReview(@RequestBody ReviewRequestDto dto) {
+        ReviewResponseDto created = reviewService.createReview(dto);
+        return ResponseEntity.created(URI.create("/api/reviews/" + created.getId()))
+                .body(created);
+    }
+
+    // 🔹 전체 후기 목록
+    @GetMapping
+    public ResponseEntity<List<ReviewResponseDto>> getAllReviews() {
+        List<ReviewResponseDto> reviews = reviewService.getAllReviews();
+        return ResponseEntity.ok(reviews);
+    }
+
+    // 🔹 단일 후기 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<ReviewResponseDto> getReview(@PathVariable Long id) {
+        ReviewResponseDto review = reviewService.getReviewById(id);
+        return ResponseEntity.ok(review);
+    }
+
+    // 🔹 후기 수정
+    @PutMapping("/{id}")
+    public ResponseEntity<ReviewResponseDto> updateReview(@PathVariable Long id,
+                                                          @RequestBody ReviewRequestDto dto) {
+        ReviewResponseDto updated = reviewService.updateReview(id, dto);
+        return ResponseEntity.ok(updated);
+    }
+
+    // 🔹 후기 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteReview(@PathVariable Long id) {
+        reviewService.deleteReview(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/curpick/CurPick/domain/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/curpick/CurPick/domain/review/dto/ReviewRequestDto.java
@@ -1,4 +1,4 @@
-package com.curpick.CurPick.domain.review.dto.request;
+package com.curpick.CurPick.domain.review.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;

--- a/src/main/java/com/curpick/CurPick/domain/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/curpick/CurPick/domain/review/dto/ReviewRequestDto.java
@@ -1,17 +1,26 @@
-package com.curpick.CurPick.domain.review.dto;
+package com.curpick.CurPick.domain.review.dto.request;
 
-
-import lombok.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@Schema(description = "면접 후기 등록/수정 요청 DTO")
 public class ReviewRequestDto {
+
+    @Schema(description = "회사명", example = "카카오")
     private String company;
-    private int interviewerCount;
+
+    @Schema(description = "면접관 수", example = "2")
+    private Integer interviewerCount;
+
+    @Schema(description = "면접 후기 내용", example = "분위기는 편안했지만 질문은 다소 날카로웠어요.")
     private String review;
-    private int difficulty;
-    private int mood;
+
+    @Schema(description = "난이도 (1~5)", example = "3")
+    private Integer difficulty;
+
+    @Schema(description = "분위기 (1~5)", example = "4")
+    private Integer mood;
 }

--- a/src/main/java/com/curpick/CurPick/domain/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/curpick/CurPick/domain/review/dto/ReviewRequestDto.java
@@ -1,0 +1,17 @@
+package com.curpick.CurPick.domain.review.dto;
+
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewRequestDto {
+    private String company;
+    private int interviewerCount;
+    private String review;
+    private int difficulty;
+    private int mood;
+}

--- a/src/main/java/com/curpick/CurPick/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/curpick/CurPick/domain/review/dto/ReviewResponseDto.java
@@ -1,21 +1,37 @@
-package com.curpick.CurPick.domain.review.dto;
+package com.curpick.CurPick.domain.review.dto.response;
 
-import lombok.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
+@Schema(description = "면접 후기 응답 DTO")
 public class ReviewResponseDto {
+
+    @Schema(description = "리뷰 ID", example = "1")
     private Long id;
+
+    @Schema(description = "회사명", example = "카카오")
     private String company;
-    private int interviewerCount;
+
+    @Schema(description = "면접관 수", example = "2")
+    private Integer interviewerCount;
+
+    @Schema(description = "면접 후기 내용", example = "분위기는 편안했지만 질문은 다소 날카로웠어요.")
     private String review;
-    private int difficulty;
-    private int mood;
+
+    @Schema(description = "난이도 (1~5)", example = "3")
+    private Integer difficulty;
+
+    @Schema(description = "분위기 (1~5)", example = "4")
+    private Integer mood;
+
+    @Schema(description = "등록일시", example = "2025-06-12T15:00:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "수정일시", example = "2025-06-12T15:05:00")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/curpick/CurPick/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/curpick/CurPick/domain/review/dto/ReviewResponseDto.java
@@ -1,0 +1,21 @@
+package com.curpick.CurPick.domain.review.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewResponseDto {
+    private Long id;
+    private String company;
+    private int interviewerCount;
+    private String review;
+    private int difficulty;
+    private int mood;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/curpick/CurPick/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/curpick/CurPick/domain/review/dto/ReviewResponseDto.java
@@ -1,4 +1,4 @@
-package com.curpick.CurPick.domain.review.dto.response;
+package com.curpick.CurPick.domain.review.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;

--- a/src/main/java/com/curpick/CurPick/domain/review/entity/Review.java
+++ b/src/main/java/com/curpick/CurPick/domain/review/entity/Review.java
@@ -1,0 +1,41 @@
+package com.curpick.CurPick.domain.review.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String company;               // 회사명
+    private int interviewerCount;         // 면접 인원
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String review;                // 면접 평가
+    private int difficulty;               // 면접 난이도 (1~5)
+    private int mood;                     // 면접 분위기 (1~5)
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/curpick/CurPick/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/curpick/CurPick/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.curpick.CurPick.domain.review.repository;
+
+import com.curpick.CurPick.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/com/curpick/CurPick/domain/review/service/ReviewService.java
+++ b/src/main/java/com/curpick/CurPick/domain/review/service/ReviewService.java
@@ -1,0 +1,88 @@
+package com.curpick.CurPick.domain.review.service;
+
+import com.curpick.CurPick.domain.review.dto.ReviewRequestDto;
+import com.curpick.CurPick.domain.review.dto.ReviewResponseDto;
+import com.curpick.CurPick.domain.review.entity.Review;
+import com.curpick.CurPick.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+    // 🔹 리뷰 생성
+    @Transactional
+    public ReviewResponseDto createReview(ReviewRequestDto dto) {
+        Review review = Review.builder()
+                .company(dto.getCompany())
+                .interviewerCount(dto.getInterviewerCount())
+                .review(dto.getReview())
+                .difficulty(dto.getDifficulty())
+                .mood(dto.getMood())
+                .build();
+
+        Review saved = reviewRepository.save(review);
+        return toDto(saved);
+    }
+
+    // 🔹 전체 리뷰 조회
+    @Transactional(readOnly = true)
+    public List<ReviewResponseDto> getAllReviews() {
+        return reviewRepository.findAll().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    // 🔹 단일 리뷰 조회
+    @Transactional(readOnly = true)
+    public ReviewResponseDto getReviewById(Long id) {
+        Review review = reviewRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("해당 리뷰를 찾을 수 없습니다."));
+        return toDto(review);
+    }
+
+    // 🔹 리뷰 수정
+    @Transactional
+    public ReviewResponseDto updateReview(Long id, ReviewRequestDto dto) {
+        Review review = reviewRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("수정할 리뷰가 존재하지 않습니다."));
+
+        review.setCompany(dto.getCompany());
+        review.setInterviewerCount(dto.getInterviewerCount());
+        review.setReview(dto.getReview());
+        review.setDifficulty(dto.getDifficulty());
+        review.setMood(dto.getMood());
+
+        return toDto(review);
+    }
+
+    // 🔹 리뷰 삭제
+    @Transactional
+    public void deleteReview(Long id) {
+        if (!reviewRepository.existsById(id)) {
+            throw new RuntimeException("삭제할 리뷰가 존재하지 않습니다.");
+        }
+        reviewRepository.deleteById(id);
+    }
+
+    // 🔹 Entity → DTO 변환
+    private ReviewResponseDto toDto(Review review) {
+        return ReviewResponseDto.builder()
+                .id(review.getId())
+                .company(review.getCompany())
+                .interviewerCount(review.getInterviewerCount())
+                .review(review.getReview())
+                .difficulty(review.getDifficulty())
+                .mood(review.getMood())
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## 기능구현

### 면접 후기 CRUD API 구현
- 후기 등록, 조회, 수정, 삭제 기능 구현
- DTO, Service, Controller, Entity 구성

### Review 엔티티에 @Lob 적용 및 TEXT 컬럼 설정
- 긴 후기 텍스트 저장 가능하도록 설정

### Swagger 문서화 어노테이션 적용
- DTO에 @Schema 어노테이션 추가
- 예제값 및 설명 문서화

### 테스트
- 면접 후기 등록
![image](https://github.com/user-attachments/assets/c51a880e-9b9b-464b-b94f-d136b8f529d8)
- 전체 조회
![image](https://github.com/user-attachments/assets/9d633322-3e46-4408-8852-959e11367b08)
- 상세 조회
![image](https://github.com/user-attachments/assets/a6768679-b600-4f51-af31-b294447b3cb9)
- 수정
![image](https://github.com/user-attachments/assets/18b669aa-0d1c-4187-ba19-295e7cd70132)
- 삭제  
![image](https://github.com/user-attachments/assets/ce4393cd-88d5-4d3f-a4a3-fc139db4ac08)