### PR TITLE
[feat] 직업정보 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,17 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	implementation 'org.json:json:20240303'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// 기존에 웹 MVC 쓰고 있으면 얘도 필요할 수 있음
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// XML 매핑용
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/curpick/CurPick/domain/worknet/controller/WorknetController.java
+++ b/src/main/java/com/curpick/CurPick/domain/worknet/controller/WorknetController.java
@@ -14,15 +14,20 @@ import org.springframework.web.bind.annotation.*;
 public class WorknetController {
 
     private final WorknetService service;
-    private static final Logger log = LoggerFactory.getLogger(WorknetController.class); // 로그 추가
+    private static final Logger log = LoggerFactory.getLogger(WorknetController.class);
 
-    @GetMapping("/job")
-    public ResponseEntity<WorknetResponseDto> getJobInfoByCode(@RequestParam String code) {
+    /**
+     * 전체 직업 목록 조회
+     */
+    @GetMapping("/jobs") // URL도 복수형으로
+    public ResponseEntity<WorknetResponseDto> getAllJobs() {
         try {
-            WorknetResponseDto res = service.fetchJobByCode(code);
+            log.info("[WorknetController] 전체 직업 목록 요청 시작");
+            WorknetResponseDto res = service.fetchAllJobs();
+            log.info("[WorknetController] 전체 직업 목록 요청 성공");
             return ResponseEntity.ok(res);
         } catch (Exception e) {
-            log.error("[WorknetController] 직업 코드 기반 API 호출 오류", e);
+            log.error("[WorknetController] 전체 직업 목록 조회 실패", e);
             return ResponseEntity.status(500).build();
         }
     }

--- a/src/main/java/com/curpick/CurPick/domain/worknet/controller/WorknetController.java
+++ b/src/main/java/com/curpick/CurPick/domain/worknet/controller/WorknetController.java
@@ -8,27 +8,22 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/worknet")
 @RequiredArgsConstructor
 public class WorknetController {
 
-    private final WorknetService service;
-    private static final Logger log = LoggerFactory.getLogger(WorknetController.class);
+    private final WorknetService worknetService;
 
-    /**
-     * 전체 직업 목록 조회
-     */
-    @GetMapping("/jobs") // URL도 복수형으로
-    public ResponseEntity<WorknetResponseDto> getAllJobs() {
-        try {
-            log.info("[WorknetController] 전체 직업 목록 요청 시작");
-            WorknetResponseDto res = service.fetchAllJobs();
-            log.info("[WorknetController] 전체 직업 목록 요청 성공");
-            return ResponseEntity.ok(res);
-        } catch (Exception e) {
-            log.error("[WorknetController] 전체 직업 목록 조회 실패", e);
-            return ResponseEntity.status(500).build();
-        }
+    @GetMapping("/jobs")
+    public ResponseEntity<List<WorknetResponseDto.Job>> getJobs(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "15") int size) throws Exception {
+
+        List<WorknetResponseDto.Job> jobs = worknetService.getJobsByPage(page, size);
+
+        return ResponseEntity.ok(jobs);
     }
 }

--- a/src/main/java/com/curpick/CurPick/domain/worknet/controller/WorknetController.java
+++ b/src/main/java/com/curpick/CurPick/domain/worknet/controller/WorknetController.java
@@ -1,0 +1,29 @@
+package com.curpick.CurPick.domain.worknet.controller;
+
+import com.curpick.CurPick.domain.worknet.dto.WorknetResponseDto;
+import com.curpick.CurPick.domain.worknet.service.WorknetService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/worknet")
+@RequiredArgsConstructor
+public class WorknetController {
+
+    private final WorknetService service;
+    private static final Logger log = LoggerFactory.getLogger(WorknetController.class); // 로그 추가
+
+    @GetMapping("/job")
+    public ResponseEntity<WorknetResponseDto> getJobInfoByCode(@RequestParam String code) {
+        try {
+            WorknetResponseDto res = service.fetchJobByCode(code);
+            return ResponseEntity.ok(res);
+        } catch (Exception e) {
+            log.error("[WorknetController] 직업 코드 기반 API 호출 오류", e);
+            return ResponseEntity.status(500).build();
+        }
+    }
+}

--- a/src/main/java/com/curpick/CurPick/domain/worknet/dto/WorknetResponseDto.java
+++ b/src/main/java/com/curpick/CurPick/domain/worknet/dto/WorknetResponseDto.java
@@ -3,6 +3,7 @@ package com.curpick.CurPick.domain.worknet.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,14 +11,19 @@ import java.util.List;
 
 @Getter @Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JacksonXmlRootElement(localName = "jobsList")
 public class WorknetResponseDto {
+
     @JacksonXmlProperty(localName = "total")
     private int total;
 
-    @JacksonXmlProperty(localName = "jobList") // jobList 안에 단일 job 객체가 있어서
-    private Job jobList;
+    @JacksonXmlElementWrapper(useWrapping = false)
+    @JacksonXmlProperty(localName = "jobList")
+    private List<Job> jobList;
 
-    @Getter @Setter
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Job {
         @JacksonXmlProperty(localName = "jobClcd")
         private String jobClcd;

--- a/src/main/java/com/curpick/CurPick/domain/worknet/dto/WorknetResponseDto.java
+++ b/src/main/java/com/curpick/CurPick/domain/worknet/dto/WorknetResponseDto.java
@@ -1,0 +1,34 @@
+package com.curpick.CurPick.domain.worknet.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter @Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WorknetResponseDto {
+    @JacksonXmlProperty(localName = "total")
+    private int total;
+
+    @JacksonXmlProperty(localName = "jobList") // jobList 안에 단일 job 객체가 있어서
+    private Job jobList;
+
+    @Getter @Setter
+    public static class Job {
+        @JacksonXmlProperty(localName = "jobClcd")
+        private String jobClcd;
+
+        @JacksonXmlProperty(localName = "jobClcdNM")
+        private String jobClcdNM;
+
+        @JacksonXmlProperty(localName = "jobCd")
+        private String jobCd;
+
+        @JacksonXmlProperty(localName = "jobNm")
+        private String jobNm;
+    }
+}

--- a/src/main/java/com/curpick/CurPick/domain/worknet/service/WorknetService.java
+++ b/src/main/java/com/curpick/CurPick/domain/worknet/service/WorknetService.java
@@ -2,35 +2,46 @@ package com.curpick.CurPick.domain.worknet.service;
 
 import com.curpick.CurPick.domain.worknet.dto.WorknetResponseDto;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 
+@Slf4j
 @Service
-@RequiredArgsConstructor
 public class WorknetService {
 
     @Value("${worknet.auth.key}")
     private String authKey;
 
-    private final WebClient webClient = WebClient.create();
-    private final XmlMapper xmlMapper = new XmlMapper();
+    private final WebClient webClient;
+    private final XmlMapper xmlMapper;
 
-    public WorknetResponseDto fetchJobByCode(String jobCode) throws Exception {
+    public WorknetService() {
+        this.webClient = WebClient.builder().build();
+        this.xmlMapper = new XmlMapper(); // 직접 생성
+    }
+
+    public WorknetResponseDto fetchAllJobs() throws Exception {
         String url = String.format(
                 "https://www.work24.go.kr/cm/openApi/call/wk/callOpenApiSvcInfo212L01.do" +
-                        "?authKey=%s&returnType=XML&target=JOBCD&jobcd=%s",
-                authKey, jobCode
+                        "?authKey=%s&returnType=XML&target=JOBCD",
+                authKey
         );
 
-        String xml = webClient.get()
-                .uri(url)
-                .retrieve()
-                .bodyToMono(String.class)
-                .block();
+        try {
+            log.info("[WorknetService] 전체 직업 목록 요청: {}", url);
 
-        return xmlMapper.readValue(xml, WorknetResponseDto.class);
+            String xml = webClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            return xmlMapper.readValue(xml, WorknetResponseDto.class);
+        } catch (Exception e) {
+            log.error("[WorknetService] 전체 직업 목록 조회 실패", e);
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/curpick/CurPick/domain/worknet/service/WorknetService.java
+++ b/src/main/java/com/curpick/CurPick/domain/worknet/service/WorknetService.java
@@ -1,0 +1,36 @@
+package com.curpick.CurPick.domain.worknet.service;
+
+import com.curpick.CurPick.domain.worknet.dto.WorknetResponseDto;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class WorknetService {
+
+    @Value("${worknet.auth.key}")
+    private String authKey;
+
+    private final WebClient webClient = WebClient.create();
+    private final XmlMapper xmlMapper = new XmlMapper();
+
+    public WorknetResponseDto fetchJobByCode(String jobCode) throws Exception {
+        String url = String.format(
+                "https://www.work24.go.kr/cm/openApi/call/wk/callOpenApiSvcInfo212L01.do" +
+                        "?authKey=%s&returnType=XML&target=JOBCD&jobcd=%s",
+                authKey, jobCode
+        );
+
+        String xml = webClient.get()
+                .uri(url)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+        return xmlMapper.readValue(xml, WorknetResponseDto.class);
+    }
+}

--- a/src/main/java/com/curpick/CurPick/domain/worknet/service/WorknetService.java
+++ b/src/main/java/com/curpick/CurPick/domain/worknet/service/WorknetService.java
@@ -2,26 +2,27 @@ package com.curpick.CurPick.domain.worknet.service;
 
 import com.curpick.CurPick.domain.worknet.dto.WorknetResponseDto;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.Collections;
+import java.util.List;
+
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class WorknetService {
 
     @Value("${worknet.auth.key}")
     private String authKey;
 
-    private final WebClient webClient;
-    private final XmlMapper xmlMapper;
+    private final WebClient webClient = WebClient.create();
+    private final XmlMapper xmlMapper = new XmlMapper();
 
-    public WorknetService() {
-        this.webClient = WebClient.builder().build();
-        this.xmlMapper = new XmlMapper(); // 직접 생성
-    }
-
+    // 전체 직업 목록 한 번에 가져오는 메서드
     public WorknetResponseDto fetchAllJobs() throws Exception {
         String url = String.format(
                 "https://www.work24.go.kr/cm/openApi/call/wk/callOpenApiSvcInfo212L01.do" +
@@ -29,19 +30,31 @@ public class WorknetService {
                 authKey
         );
 
-        try {
-            log.info("[WorknetService] 전체 직업 목록 요청: {}", url);
+        String xml = webClient.get()
+                .uri(url)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
 
-            String xml = webClient.get()
-                    .uri(url)
-                    .retrieve()
-                    .bodyToMono(String.class)
-                    .block();
+        return xmlMapper.readValue(xml, WorknetResponseDto.class);
+    }
 
-            return xmlMapper.readValue(xml, WorknetResponseDto.class);
-        } catch (Exception e) {
-            log.error("[WorknetService] 전체 직업 목록 조회 실패", e);
-            throw e;
+    // 페이징 처리된 직업 목록 반환
+    public List<WorknetResponseDto.Job> getJobsByPage(int pageNo, int pageSize) throws Exception {
+        WorknetResponseDto fullResponse = fetchAllJobs();
+        List<WorknetResponseDto.Job> jobs = fullResponse.getJobList();
+
+        if (jobs == null || jobs.isEmpty()) {
+            return Collections.emptyList();
         }
+
+        int start = (pageNo - 1) * pageSize;
+        if (start >= jobs.size()) {
+            return Collections.emptyList();
+        }
+
+        int end = Math.min(start + pageSize, jobs.size());
+
+        return jobs.subList(start, end);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,3 +21,7 @@ spring:
           connectiontimeout: 5000
           timeout: 5000
           writetimeout: 5000
+
+worknet:
+  auth:
+    key: ${WORKNET_KEY}


### PR DESCRIPTION
## Worknet API 전체 직업 목록 조회 및 페이징 기능 구현
- WorknetService에 전체 직업 목록을 XML API로 호출해 파싱하는 기능 추가
- WorknetResponseDto DTO 수정 (jobList 필드를 List<Job> 타입으로 변경, XML 구조에 맞게 어노테이션 조정)
- 전체 직업 목록 조회 시 XML 응답에서 여러 개 jobList 요소를 List로 매핑하도록 개선
- WebClient를 사용해 Worknet 공공 API 호출 및 XML 응답 처리 로직 작성
- 전체 직업 목록 페이징 처리 메서드 추가 (서버에서 페이지 번호와 크기 기준으로 데이터 슬라이스 반환)
- WorknetController에 페이징 쿼리 파라미터 (page, size)를 받아서 페이징 처리된 직업 리스트 반환 API 구현

## 테스트
![image](https://github.com/user-attachments/assets/31d422af-655e-4596-b084-8d46e053be26)
![image](https://github.com/user-attachments/assets/38675bdb-c69d-49cf-bbab-aa2c6f79349f)
